### PR TITLE
fixing proper use of exp in generateKeyPair(b, exp) and tests

### DIFF
--- a/src/NodeRSA.js
+++ b/src/NodeRSA.js
@@ -45,9 +45,9 @@ module.exports = (function() {
      */
     NodeRSA.prototype.generateKeyPair = function(bits, exp) {
         bits = bits || 2048;
-        exp = 65537;
+        exp = exp || 65537;
 
-        if (bits % 8 != 0) {
+        if (bits % 8 !== 0) {
             throw Error('Key size must be a multiple of 8.');
         }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -60,9 +60,17 @@ describe("NodeRSA", function(){
         describe("Generating keys", function() {
             for (var size in keySizes) {
                 (function(size){
-                    it("should make key pair " + size.b + "-bit length and public exponent is " + (size.e || 65537), function () {
+                    it("should make key pair " + size.b + "-bit length and public exponent is " + size.e, function () {
                         generatedKeys.push(new NodeRSA({b: size.b, e: size.e}));
                         assert.instanceOf(generatedKeys[generatedKeys.length - 1].keyPair, Object);
+
+                        if (size.e != null && size.e != undefined)
+                        {
+                            assert.equal(generatedKeys[generatedKeys.length - 1].keyPair.e, size.e);
+                        } else {
+                            assert.equal(generatedKeys[generatedKeys.length - 1].keyPair.e, 65537);
+                        }
+
                         assert.equal(generatedKeys[generatedKeys.length - 1].getKeySize(), size.b);
                         assert.equal(generatedKeys[generatedKeys.length - 1].getMaxMessageSize(), (size.b / 8 - 11));
                     });


### PR DESCRIPTION
Hi,

there was a bug in NodeRSA.prototype.generateKeyPair(bits, exp) which lead to a wrong assumption of what value the exponent variable exp actually has.

I've also fixed the tests for it.

kind Regards,

Thomas
