### PR TITLE
Fixing global variable leak in schemes.js.

### DIFF
--- a/src/schemes/schemes.js
+++ b/src/schemes/schemes.js
@@ -1,4 +1,4 @@
-module.exports = schemes = {
+var schemes = {
     pkcs1: require('./pkcs1'),
     pkcs1_oaep: require('./oaep'),
     pss: require('./pss'),
@@ -21,3 +21,5 @@ module.exports = schemes = {
         return schemes[scheme] && schemes[scheme].isSignature;
     }
 };
+
+module.exports = schemes;


### PR DESCRIPTION
Currently, the module export in schemes.js also writes to an intermediate variable (`schemes`), which is in the global-space.  This fix addresses this issue by declaring schemes and exporting at the end of the file.