### PR TITLE
Webpack compatibility

### DIFF
--- a/src/schemes/oaep.js
+++ b/src/schemes/oaep.js
@@ -48,10 +48,10 @@ module.exports.eme_oaep_mgf1 = function (seed, maskLength, hashFunction) {
     var c = new Buffer(4);
     for (var i = 0; i < count; ++i) {
         var hash = crypt.createHash(hashFunction);
-        hash.write(seed);
+        hash.update(seed);
         c.writeUInt32BE(i, 0);
-        hash.end(c);
-        hash.read().copy(T, i * hLen);
+        hash.update(c);
+        hash.digest().copy(T, i * hLen);
     }
     return T.slice(0, maskLength);
 };


### PR DESCRIPTION
Hey @rzcoder 

I was wondering about the choice of `write/end/read` as opposed to `update/digest`. Were there different performance/memory characteristics between using the stream functions instead of the hash functions? Or some implementation detail between the two that I'm missing? Or did you just decide to use the stream methods because they're the new ones (totally understandable)?

It appears that these are not going to be deprecated soon, the nodejs docs say "The legacy update and digest methods are also supported." https://nodejs.org/api/crypto.html#crypto_class_hash

This issue came up for me because `webpack` apparently has a problem where their implementations of the nodejs hash functions are not streams (or for some other reason don't implement `write/end/read` -- it's a harder to decipher their code than yours). So if I wanted to use the OAEP encryption scheme (you bet I do!) with `node-rsa` and `webpack`, one of those codebases need to change.

Worth noting, in `Scheme.prototype.encPad` you use `update/digest` as well. 

Would you consider accepting this change?