### PR TITLE
add RSA_NO_PADDING support compatible with bouncycastle

### DIFF
--- a/src/encryptEngines/io.js
+++ b/src/encryptEngines/io.js
@@ -7,16 +7,22 @@ module.exports = function (keyPair, options) {
     return {
         encrypt: function (buffer, usePrivate) {
             if (usePrivate) {
+                var padding = constants.RSA_PKCS1_PADDING;
+                if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                    padding = options.encryptionSchemeOptions.padding;
+                }
                 return crypto.privateEncrypt({
                     key: options.rsaUtils.exportKey('private'),
-                    padding: constants.RSA_PKCS1_PADDING
+                    padding: padding
                 }, buffer);
             } else {
                 var padding = constants.RSA_PKCS1_OAEP_PADDING;
                 if (options.encryptionScheme === 'pkcs1') {
                     padding = constants.RSA_PKCS1_PADDING;
                 }
-
+                if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                    padding = options.encryptionSchemeOptions.padding;
+                }
                 return crypto.publicEncrypt({
                     key: options.rsaUtils.exportKey('public'),
                     padding: padding
@@ -26,16 +32,22 @@ module.exports = function (keyPair, options) {
 
         decrypt: function (buffer, usePublic) {
             if (usePublic) {
+                var padding = constants.RSA_PKCS1_PADDING;
+                if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                    padding = options.encryptionSchemeOptions.padding;
+                }
                 return crypto.publicDecrypt({
                     key: options.rsaUtils.exportKey('public'),
-                    padding: constants.RSA_PKCS1_PADDING
+                    padding: padding
                 }, buffer);
             } else {
                 var padding = constants.RSA_PKCS1_OAEP_PADDING;
                 if (options.encryptionScheme === 'pkcs1') {
                     padding = constants.RSA_PKCS1_PADDING;
                 }
-
+                if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                    padding = options.encryptionSchemeOptions.padding;
+                }
                 return crypto.privateDecrypt({
                     key: options.rsaUtils.exportKey('private'),
                     padding: padding

--- a/src/encryptEngines/node12.js
+++ b/src/encryptEngines/node12.js
@@ -13,6 +13,9 @@ module.exports = function (keyPair, options) {
             if (options.encryptionScheme === 'pkcs1') {
                 padding = constants.RSA_PKCS1_PADDING;
             }
+            if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                padding = options.encryptionSchemeOptions.padding;
+            }
 
             return crypto.publicEncrypt({
                 key: options.rsaUtils.exportKey('public'),
@@ -27,6 +30,9 @@ module.exports = function (keyPair, options) {
             var padding = constants.RSA_PKCS1_OAEP_PADDING;
             if (options.encryptionScheme === 'pkcs1') {
                 padding = constants.RSA_PKCS1_PADDING;
+            }
+            if (options.encryptionSchemeOptions && options.encryptionSchemeOptions.padding) {
+                padding = options.encryptionSchemeOptions.padding;
             }
 
             return crypto.privateDecrypt({

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,6 +3,7 @@ var assert = require('chai').assert;
 var _ = require('lodash');
 var NodeRSA = require('../src/NodeRSA');
 var OAEP = require('../src/schemes/oaep');
+var constants = require('constants');
 
 describe('NodeRSA', function () {
     var keySizes = [
@@ -16,7 +17,7 @@ describe('NodeRSA', function () {
     ];
 
     var environments = ['browser', 'node'];
-    var encryptSchemes = ['pkcs1', 'pkcs1_oaep'];
+    var encryptSchemes = ['pkcs1', 'pkcs1_oaep', {scheme:'pkcs1', encryptionScheme:{padding: constants.RSA_NO_PADDING}}];
     var signingSchemes = ['pkcs1', 'pss'];
     var signHashAlgorithms = {
         'node': ['MD4', 'MD5', 'RIPEMD160', 'SHA', 'SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512'],
@@ -116,7 +117,8 @@ describe('NodeRSA', function () {
                 encryptionScheme: {
                     scheme: 'pkcs1_oaep',
                     hash: 'sha512',
-                    label: 'horay'
+                    label: 'horay',
+                    padding: constants.RSA_NO_PADDING
                 },
                 signingScheme: {
                     scheme: 'pss',
@@ -131,6 +133,7 @@ describe('NodeRSA', function () {
             assert.equal(key.$options.encryptionScheme, 'pkcs1_oaep');
             assert.equal(key.$options.encryptionSchemeOptions.hash, 'sha512');
             assert.equal(key.$options.encryptionSchemeOptions.label, 'horay');
+            assert.equal(key.$options.encryptionSchemeOptions.padding, constants.RSA_NO_PADDING);
         });
 
         it('should throw \'unsupported hashing algorithm\' exception', function () {


### PR DESCRIPTION
usage:
```
var publicKey = fs.readFileSync('public_pkcs1.pem');
var privateKey = fs.readFileSync('private_pkcs1.pem');

var text = "Hello World";
var public = new NodeRSA(publicKey, 'pkcs1-public', {encryptionScheme:{scheme:'pkcs1', padding: constants.RSA_NO_PADDING}});
var private = new NodeRSA(privateKey, 'pkcs1-private', {encryptionScheme:{scheme:'pkcs1', padding: constants.RSA_NO_PADDING}});
var encrypted = public.encrypt(text, 'buffer');
console.log(encrypted);
var decrypted = private.decrypt(encrypted, 'utf-8');
console.log('decrypted: ', decrypted);
```