### PR TITLE
NodeRSA.importKey() now returns this

### DIFF
--- a/src/NodeRSA.js
+++ b/src/NodeRSA.js
@@ -185,8 +185,10 @@ module.exports = (function () {
         if (!formats.detectAndImport(this.keyPair, keyData, format) && format === undefined) {
             throw Error("Key format must be specified");
         }
-
+        
         this.$cache = {};
+        
+        return this;
     };
 
     /**


### PR DESCRIPTION
Sometimes we find the need to daisy chain or nest functions, and I felt that returning "`this`" would allow that to happen. This would let people do stuff like
`new NodeRSA().importKey(...)`, although `new NodeRSA(...)` would technically be advantageous