### PR TITLE
pkcs1 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tmp
 node_modules/
 .nyc_output
+nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .tmp
 node_modules/
 .nyc_output
-nbproject/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rsa",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-rsa",
-  "version": "1.0.5",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/schemes/pkcs1.js
+++ b/src/schemes/pkcs1.js
@@ -113,7 +113,7 @@ module.exports.makeScheme = function (key, options) {
 
         /* Type 1: zeros padding for private key decrypt */
         if (options.type === 1) {
-            if (buffer[0] !== 0 || buffer[1] !== 1) {
+            if (buffer[0] !== 0 && buffer[1] !== 1) {
                 return null;
             }
             i = 3;
@@ -124,7 +124,7 @@ module.exports.makeScheme = function (key, options) {
             }
         } else {
             /* random padding for public key decrypt */
-            if (buffer[0] !== 0 || buffer[1] !== 2) {
+            if (buffer[0] !== 0 && buffer[1] !== 2) {
                 return null;
             }
             i = 3;

--- a/src/schemes/pkcs1.js
+++ b/src/schemes/pkcs1.js
@@ -113,7 +113,7 @@ module.exports.makeScheme = function (key, options) {
 
         /* Type 1: zeros padding for private key decrypt */
         if (options.type === 1) {
-            if (buffer[0] !== 0 && buffer[1] !== 1) {
+            if (buffer[0] !== 0 || buffer[1] !== 1) {
                 return null;
             }
             i = 3;
@@ -124,7 +124,7 @@ module.exports.makeScheme = function (key, options) {
             }
         } else {
             /* random padding for public key decrypt */
-            if (buffer[0] !== 0 && buffer[1] !== 2) {
+            if (buffer[0] !== 0 || buffer[1] !== 2) {
                 return null;
             }
             i = 3;


### PR DESCRIPTION
fix: pkcs1 returned Buffer object when data were invalid. 

I found it when I tried to decrypt data with different padding type than i used during encryption. It was bug in my code. But the library returns invalid data instead of throw an error. 

Your code contains some checks for this case, but there is AND instead of OR operator. My data had first byte 0 and second byte random value. In this case the condition failed.

I supose that the library have to throws an error, when first byte is not 0 and second is not 2 during decryption with padding pkcs1. 