### PR TITLE
fix: get32IntFromBuffer to handle arbitary sizes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,7 @@ module.exports.get32IntFromBuffer = function (buffer, offset) {
     var size = 0;
     if ((size = buffer.length - offset) > 0) {
         if (size >= 4) {
-            return buffer.readUInt32BE(offset);
+            return buffer.readUIntBE(offset, size);
         } else {
             var res = 0;
             for (var i = offset + size, d = 0; i > offset; i--, d += 2) {


### PR DESCRIPTION
As we know the size for fact, and in some cases ( exponent bigger than 65537 ) the current buffer method ```readUInt32BE``` gives unexpected results, it is better to utilise the more general ```readUIntBE``` buffer function combined with size in order to get the right results.