### PR TITLE
Always return a boolean from NodeRSA.isPrivate

### DIFF
--- a/src/libs/rsa.js
+++ b/src/libs/rsa.js
@@ -272,7 +272,7 @@ module.exports.Key = (function () {
      * Check if key pair contains private key
      */
     RSAKey.prototype.isPrivate = function () {
-        return this.n && this.e && this.d || false;
+        return this.n && this.e && this.d && true || false;
     };
 
     /**


### PR DESCRIPTION
Currently, the `NodeRSA.isPrivate` method returns the `d` component of
the key when the key is indeed a private key. Obviously, this result
is truthy and hence does the job. However, I would classify it as a
security risk since the name `isPrivate` raises the expectation that
the result is a boolean and hence can safely be sent over the wire.
This might leak the most private part of the key though, which would
most likely be a disaster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rzcoder/node-rsa/173)
<!-- Reviewable:end -->
